### PR TITLE
Update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "eslint-plugin-typescript": "^0.14.0",
     "husky": "^1.3.0",
     "nodemon": "^1.18.9",
-    "nyc": "^13.1.0",
+    "nyc": "^14.0.0",
     "pino-pretty": "^2.5.0",
     "sinon": "^7.2.2",
     "ts-node": "^7.0.1",
@@ -80,8 +80,7 @@
     "koa-router": "^7.4.0",
     "koa-sslify": "^2.2.0",
     "mysql": "^2.16.0",
-    "mysql2": "^1.6.4",
-    "sequelize": "^4.42.0",
+    "sequelize": "^5.3.0",
     "sodium-native": "^2.2.3",
     "stripe": "^6.23.1"
   }


### PR DESCRIPTION
Security alert for `sequelize` should be resolved with this. Breaking changes from v4 to v5 are documented [here](https://github.com/sequelize/sequelize/releases/tag/v5.1.0) but I don't think they will break anything we have. 

Also removed `mysql2` dependency as it wasn't being used and updated `nyc` to resolve a moderate security issue.